### PR TITLE
Add ignore_query configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Flog.configure do |config|
   config.params_key_count_threshold = 2
   # If this value is true, nested Hash parameter is formatted coercively in any situation
   config.force_on_nested_params = false
+  # If this value is true, not format query
+  config.ignore_query = true
 end
 ```
 
@@ -112,6 +114,7 @@ end
 |query_duration_threshold   |float     |0.0           |
 |params_key_count_threshold |integer   |1             |
 |force_on_nested_params     |boolean   |true          |
+|ignore_query               |boolean   |false         |
 
 ## Disable temporary
 

--- a/lib/flog/configuration.rb
+++ b/lib/flog/configuration.rb
@@ -9,7 +9,7 @@ module Flog
   # Configuration of this gem.
   # Call `configure` to setup.
   class Configuration
-    attr_writer :ignore_cached_query, :force_on_nested_params
+    attr_writer :ignore_cached_query, :force_on_nested_params, :ignore_query
     attr_accessor :query_duration_threshold, :params_key_count_threshold, :sql_indent, :sql_in_values_num
 
     def initialize
@@ -19,14 +19,19 @@ module Flog
       @force_on_nested_params = true
       @sql_indent = "\t"
       @sql_in_values_num = 1
+      @ignore_query = false
     end
 
     def ignore_cached_query?
-      !!@ignore_cached_query
+      !!@ignore_cached_query || @ignore_query
     end
 
     def force_on_nested_params?
       !!@force_on_nested_params
+    end
+
+    def ignore_query?
+      @ignore_query
     end
   end
 

--- a/lib/flog/sql_formattable.rb
+++ b/lib/flog/sql_formattable.rb
@@ -36,6 +36,7 @@ module Flog
 
     def formattable?(event)
       return false unless Flog::Status.sql_formattable?
+      return false if Flog.config.ignore_query?
 
       return false if ignore_by_cached_query?(event)
 

--- a/test/unit/sql_formattable_test.rb
+++ b/test/unit/sql_formattable_test.rb
@@ -127,6 +127,24 @@ class SqlFormattableTest < ActiveSupport::TestCase
     end
   end
 
+  def test_sql_is_not_formatted_on_cached_query_when_ignore_query_configuration_is_true
+    configure(ignore_cached_query: false, ignore_query: true)
+    prepare_for_query_cache
+    assert_logger do |logger|
+      logger.debugs.each do |log|
+        assert_one_line_sql log if log.include?('CACHE')
+      end
+    end
+  end
+
+  def test_sql_is_not_formatted_when_ignore_query_configuration_is_true
+    configure(ignore_query: true)
+    Book.where(category: 'comics').to_a
+    assert_logger do |logger|
+      assert_one_line_sql logger.debugs.first
+    end
+  end
+
   def test_sql_is_not_formatted_when_duration_is_under_threshold
     configure(query_duration_threshold: 100.0)
     Book.where(category: 'comics').to_a


### PR DESCRIPTION
I met the case where we wanted to enable only the parameters.
This case is not temporary, it's permanent.

Right now, we can't disable sql query format by code when we want to disable it.
So, I changed to can disable sql query format on code.

Thank you 👍✨✨ 